### PR TITLE
Fixing indexing issue where we try to convert an array into an int

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ isort.required-imports = ["from __future__ import annotations"]
 
 
 [tool.pylint]
-py-version = "3.9"
+py-version = "3.10"
 ignore-paths = [".*/_version.py"]
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "A package to produce cutouts of (remote) FITS files."
 readme = "README.md"
 license.file = "LICENSE"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 1 - Planning",
   "Intended Audience :: Science/Research",
@@ -98,7 +98,7 @@ report.exclude_also = [
 
 [tool.mypy]
 files = ["src", "tests"]
-python_version = "3.10"
+python_version = "3.9"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
@@ -157,7 +157,7 @@ isort.required-imports = ["from __future__ import annotations"]
 
 
 [tool.pylint]
-py-version = "3.10"
+py-version = "3.9"
 ignore-paths = [".*/_version.py"]
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "A package to produce cutouts of (remote) FITS files."
 readme = "README.md"
 license.file = "LICENSE"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 1 - Planning",
   "Intended Audience :: Science/Research",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ report.exclude_also = [
 
 [tool.mypy]
 files = ["src", "tests"]
-python_version = "3.9"
+python_version = "3.10"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]

--- a/src/cutout_fits/cutout.py
+++ b/src/cutout_fits/cutout.py
@@ -280,7 +280,7 @@ def format_shape(wcs: WCS, shape: tuple[int, ...]) -> str:
     """
     crtypes = list(wcs.wcs.ctype)[::-1]
     shape_int = [int(s) for s in shape]
-    shape_dict = dict(zip(crtypes, shape_int, strict=False))
+    shape_dict = dict(zip(crtypes, shape_int))
     return str(shape_dict)
 
 

--- a/src/cutout_fits/cutout.py
+++ b/src/cutout_fits/cutout.py
@@ -280,7 +280,7 @@ def format_shape(wcs: WCS, shape: tuple[int, ...]) -> str:
     """
     crtypes = list(wcs.wcs.ctype)[::-1]
     shape_int = [int(s) for s in shape]
-    shape_dict = dict(zip(crtypes, shape_int))
+    shape_dict = dict(zip(crtypes, shape_int, strict=False))
     return str(shape_dict)
 
 

--- a/src/cutout_fits/cutout.py
+++ b/src/cutout_fits/cutout.py
@@ -415,8 +415,15 @@ def make_cutout(
         for ext, hdu in enumerate(hdul):
             if hdu.name == "BEAMS":
                 logger.info("Found BEAMS ext! Cutting out beam table...")
-                needs_beamtable_ext = int(np.where(needs_beamtable)[0])
-                is_beamtable_ext = int(np.where(is_beamtable)[0])
+                needs_beamtable_indices = np.where(needs_beamtable)[0]
+                is_beamtable_indices = np.where(is_beamtable)[0]
+                needs_beamtable_count = len(needs_beamtable_indices)
+                is_beamtable_count = len(is_beamtable_indices)
+                if needs_beamtable_count != 1 or is_beamtable_count != 1:
+                    msg = f"We are expecting exactly one BEAMS extension and one header that requires a beam table, but we found {is_beamtable_count} and {needs_beamtable_count}!"
+                    raise ValueError(msg)
+                needs_beamtable_ext = int(needs_beamtable_indices[0])
+                is_beamtable_ext = int(is_beamtable_indices[0])
                 assert is_beamtable_ext == ext, (
                     "Beam table extension is not where we think it is!"
                 )

--- a/tests/test_cutout.py
+++ b/tests/test_cutout.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
+from astropy.table import Table
 from astropy.wcs import WCS
 
 from cutout_fits import cutout
@@ -135,6 +136,72 @@ def temp_dir_path(tmpdir) -> Path:
     return Path(tmpdir)
 
 
+@pytest.fixture
+def beamtable_data(sample_data: SampleData, tmpdir) -> np.Generator[Path, np.Any, None]:
+    tmp_path = Path(tmpdir) / "beamtable_test.fits"
+
+    with fits.open(sample_data.data_path) as hdul:
+        image_hdu = hdul[0].copy()
+    image_hdu.header["CASAMBM"] = True
+
+    beams_table = Table(
+        {
+            "CHAN": np.arange(sample_data.n_freq, dtype=np.int32),
+            "BMAJ": np.full(sample_data.n_freq, 1.0, dtype=np.float32),
+            "BMIN": np.full(sample_data.n_freq, 1.0, dtype=np.float32),
+            "BPA": np.zeros(sample_data.n_freq, dtype=np.float32),
+        }
+    )
+    beams_hdu = fits.BinTableHDU(beams_table, name="BEAMS")
+    beams_hdu.header["NCHAN"] = sample_data.n_freq
+
+    fits.HDUList([image_hdu, beams_hdu]).writeto(tmp_path, overwrite=True)
+    yield tmp_path
+    tmp_path.unlink()
+
+
+@pytest.fixture
+def no_beamtable_data(
+    sample_data: SampleData, tmpdir
+) -> np.Generator[Path, np.Any, None]:
+    tmp_path = Path(tmpdir) / "no_beamtable_test.fits"
+
+    with fits.open(sample_data.data_path) as hdul:
+        image_hdu = hdul[0].copy()
+    image_hdu.header["CASAMBM"] = True
+
+    fits.HDUList([image_hdu]).writeto(tmp_path, overwrite=True)
+    yield tmp_path
+    tmp_path.unlink()
+
+
+@pytest.fixture
+def beamtable_without_requirement_data(
+    sample_data: SampleData, tmpdir
+) -> np.Generator[Path, np.Any, None]:
+    tmp_path = Path(tmpdir) / "beamtable_without_requirement_test.fits"
+
+    with fits.open(sample_data.data_path) as hdul:
+        image_hdu = hdul[0].copy()
+    if "CASAMBM" in image_hdu.header:
+        del image_hdu.header["CASAMBM"]
+
+    beams_table = Table(
+        {
+            "CHAN": np.arange(sample_data.n_freq, dtype=np.int32),
+            "BMAJ": np.full(sample_data.n_freq, 1.0, dtype=np.float32),
+            "BMIN": np.full(sample_data.n_freq, 1.0, dtype=np.float32),
+            "BPA": np.zeros(sample_data.n_freq, dtype=np.float32),
+        }
+    )
+    beams_hdu = fits.BinTableHDU(beams_table, name="BEAMS")
+    beams_hdu.header["NCHAN"] = sample_data.n_freq
+
+    fits.HDUList([image_hdu, beams_hdu]).writeto(tmp_path, overwrite=True)
+    yield tmp_path
+    tmp_path.unlink()
+
+
 def test_cutout_half(sample_data, center_coord, temp_dir_path):
     out_path = temp_dir_path / "temp.fits"
     cut_hdul = cutout.make_cutout(
@@ -210,3 +277,68 @@ def test_slicer_to_shape(sample_data, center_coord, temp_dir_path):
     logger.critical("%s", shape_str)
     known_str = "{'TIME': 1, 'STOKES': 4, 'FREQ': 8, 'DEC--SIN': 128, 'RA---SIN': 128}"
     assert shape_str == known_str
+
+
+def test_cutout_with_single_beamtable_extension(
+    sample_data: SampleData,
+    center_coord: SkyCoord,
+    temp_dir_path: Path,
+    beamtable_data: Path,
+):
+    out_path = temp_dir_path / "beamtable_out.fits"
+    cut_hdul = cutout.make_cutout(
+        infile=beamtable_data.as_posix(),
+        outfile=out_path.as_posix(),
+        ra_deg=center_coord.ra.deg,
+        dec_deg=center_coord.dec.deg,
+        radius_arcmin=sample_data.fov,
+        overwrite=True,
+    )
+
+    out_path.unlink()
+    assert cut_hdul is not None
+    assert len(cut_hdul) == 2
+    assert cut_hdul[1].name == "BEAMS"
+    assert cut_hdul[1].header["NCHAN"] == sample_data.n_freq
+
+
+def test_cutout_raises_when_beamtable_required_but_missing(
+    center_coord: SkyCoord,
+    temp_dir_path: Path,
+    no_beamtable_data: Path,
+):
+    out_path = temp_dir_path / "no_beamtable_out.fits"
+
+    with pytest.raises(
+        ValueError,
+        match="Beam table required in header, but no beam table extension found!",
+    ):
+        cutout.make_cutout(
+            infile=no_beamtable_data.as_posix(),
+            outfile=out_path.as_posix(),
+            ra_deg=center_coord.ra.deg,
+            dec_deg=center_coord.dec.deg,
+            radius_arcmin=60,
+            overwrite=True,
+        )
+
+
+def test_cutout_raises_when_beamtable_present_but_not_required(
+    center_coord: SkyCoord,
+    temp_dir_path: Path,
+    beamtable_without_requirement_data: Path,
+):
+    out_path = temp_dir_path / "beamtable_without_requirement_out.fits"
+
+    with pytest.raises(
+        ValueError,
+        match="Beam table extension found, but no beam table required in any header!",
+    ):
+        cutout.make_cutout(
+            infile=beamtable_without_requirement_data.as_posix(),
+            outfile=out_path.as_posix(),
+            ra_deg=center_coord.ra.deg,
+            dec_deg=center_coord.dec.deg,
+            radius_arcmin=60,
+            overwrite=True,
+        )


### PR DESCRIPTION
This pull request looks to tackle a potential bug in the code dealing with the BEAM tables. As it stood it looked like:

```python
                needs_beamtable_ext = int(np.where(needs_beamtable)[0])
                is_beamtable_ext = int(np.where(is_beamtable)[0])
```

Was giving an error as it was attempting to convert a 1D array into an into (even though the 1D array only has 1 element). 
It's not clear if this was due to a change in the python language/version or something deeper.

`np.where(is_beamtable)` returns a tuple of arrays (with only one tuple value). Thus `np.where(is_beamtable)[0]` was returning that first array. This array should at this stage only have a single element in it as we expect only a single beamtable and a extension needing a beamtable. 

Thus, we need to get the only element from this 1D array to get the actual index we want. 

* Added checks to ensure there is exactly one BEAMS extension and one header requiring a beam table before proceeding. If the counts do not match expectations, a `ValueError` is raised with a clear message.
* Took the first element of the `np.where(is_beamtable)[0]` as the index to consider.